### PR TITLE
Email address and minor text changes

### DIFF
--- a/src/components/AppLogin.vue
+++ b/src/components/AppLogin.vue
@@ -53,8 +53,8 @@
         </div>
       </Form>
       <p>
-        If you have forgotten your password, please contact the RSE team at:
-        <a href="mailto:rseteam@newcastle.ac.uk">rseteam@newcastle.ac.uk</a>
+        If you have forgotten your password, please contact the ePRaSE team at:
+        <a href="mailto:nuth.eprase@nhs.net">nuth.eprase@nhs.net</a>
       </p>
 
       <!--<p><a routerLink="">Forgotten your Password? <router-link to="/requestpassword">Click here</router-link></a><br/><br/></p>-->

--- a/src/components/AssessmentSystem.vue
+++ b/src/components/AssessmentSystem.vue
@@ -306,7 +306,7 @@
           </div>
 
           <div class="mb-4 row">
-            <label class="col-sm-8 col-form-label" for="penicillin-comment">If there is anything you would like to
+            <label class="col-sm-8 col-form-label fw-bold" for="penicillin-comment">If there is anything you would like to
               tell us about penicillin prescribing in your organisation, please record it here.</label>
             <div class="col-sm-4">
               <Field v-slot="{ field, meta }" v-model="results.penicillin_comment" name="penicillin-comment">
@@ -534,14 +534,15 @@ export default {
           // { text: 'Enteral nutrition', value: 'Enteral nutrition' },
           // { text: 'Nutritional supplements (not classed as a medicine)', value: 'Nutritional supplements' },
           // { text: 'Medicines undefined with the catalogue (free text function)', value: 'Undefined medicines' }
-          // Updates 2024-07-01
+          // Updates 2024-07-01 & 2024-10-02 (chemo => 2 options)
           { text: 'All medicines (e.g. Licensed / Unlicensed / Formulary)', value: 'All medicines' },
           { text: 'IV Infusions (e.g. Continuous / Intermittent / Complex)', value: 'IV infusions' },
           { text: 'Warfarin', value: 'Warfarin' },
           { text: 'Heparin', value: 'Heparin' },
           { text: 'Insulin', value: 'Insulin' },
           { text: 'Insulin Sliding Scales', value: 'Insulin Sliding Scales' },
-          { text: 'Chemotherapy', value: 'Chemotherapy' },
+          { text: 'Chemotherapy oral', value: 'Chemotherapy oral' },
+          { text: 'Chemotherapy IV', value: 'Chemotherapy IV'},
           { text: 'Scheduling system for Immunisations / Vaccinations', value: 'Scheduling System' },
           { text: 'Antimicrobials', value: 'Antimicrobials' },
           { text: 'Antipsychotics / Antidepressants (e.g. Depot Injections)', value: 'Antipsychotics' },


### PR DESCRIPTION
From Ellie's requests on 2024-10-01, the low-hanging fruit: changing the 'forgot password' email address to the nhs address and splitting chemotherapy into two options (oral and IV)