### PR TITLE
feat: add strapi path for backend service

### DIFF
--- a/nginx/nginx.staging.conf
+++ b/nginx/nginx.staging.conf
@@ -31,8 +31,20 @@ http {
             index       index.html;
             try_files   $uri $uri/ /index.html;
         }
-        location /admin {
+
+        location /strapi {
+            rewrite ^/strapi/?(.*)$ /$1 break;
             proxy_pass http://api:1337;
+            proxy_http_version 1.1;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Server $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_pass_request_headers on;
             # proxy_redirect     off;
             # proxy_set_header   Host $host
             # proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
This changes the subpath to be used for Strapi to /strapi. If this is changed, it must be also changed in the Strapi server configuration url.

For this container to be able to dns resolve the api container IP address, it is also required that the docker compose file names the Strapi container as 'api', for example:

container_name: api