### PR TITLE
Removes "forgot password" from welcome page

### DIFF
--- a/src/components/AppWelcome.vue
+++ b/src/components/AppWelcome.vue
@@ -11,18 +11,19 @@
           <Vueform>          
             <GroupElement name="buttonBar" :columns="12" :add-class="'mt-2'">
               <ButtonElement name="login" full
-                :columns="4" 
+                :columns="6" 
                 :add-class="'me-2'" 
                 @click="onLoginClick">
                 <i class="bi bi-person-circle me-2"></i>Log in
               </ButtonElement>            
               <ButtonElement name="register" full 
-                :columns="4" 
+                :columns="6" 
                 :add-class="'mx-2'" 
                 :disabled="$route.query.action === 'registered'" 
                 @click="onRegisterClick">
                 <i class="bi bi-person-fill-add me-2"></i>Register
               </ButtonElement>
+              <!--
               <ButtonElement name="forgotpassword" full 
                 :columns="4" 
                 :add-class="'ms-2'" 
@@ -30,6 +31,7 @@
                 @click="onForgotPasswordClick">
                 <i class="bi bi-key-fill me-2"></i>Forgot password?
               </ButtonElement>
+              -->
             </GroupElement>
           </Vueform>  
         </div>


### PR DESCRIPTION
This button  wasn't displaying the popup message about contacting ePRaSE administrators, as does happen correctly when you click the same button from the login page. I started out trying to make the popup happen from the welcome page when it occurred to me the 'forgot password' link doesn't even really need to be on the welcome page. It belongs on the login page.

So the easier fix was just to remove it from welcome. It's just commented out if anyone decides they really want it back in there.