### PR TITLE
Changes "System complete" to "System information completed"

### DIFF
--- a/src/components/AssessmentSelection.vue
+++ b/src/components/AssessmentSelection.vue
@@ -39,7 +39,7 @@
             <tr v-for="assessment in incompleteAssessments">                  
               <td>{{ assessment.ep_service.name == 'Other' ? assessment.other_ep_service : assessment.ep_service.name }}</td>
               <td>{{ assessment.patient_type }}</td>
-              <td>{{ assessment.state }}</td>
+              <td>{{ assessment.state == 'System complete' ? 'System information completed' : assessment.state }}</td>
               <td>{{ convertDate(assessment.createdAt, false) }}</td>
               <td>{{ convertDate(assessment.updatedAt, true) }}</td>
               <td>{{ assessment.eprase_creator_email || 'Not recorded' }}</td>


### PR DESCRIPTION
Per NHS request, when the assessment state shows "System complete" on the list of partially completed assessments, it might be misinterpreted to mean the whole assessment is finished. So this commit changes that text to "System information completed" while leaving the underlying stuff that gets stored in the database alone. (Changing only that display, not the actual state options.)