### PR TITLE
Modifies button text

### DIFF
--- a/src/components/AssessmentScenario.vue
+++ b/src/components/AssessmentScenario.vue
@@ -156,7 +156,8 @@
                                   <span class="fw-bold">Advisory</span> - information is provided which does not interrupt workflow or require action e.g. a passive dialogue, maybe a banner message on the bottom of the screen
                                 </li>
                               </ul>
-                              Please select <strong>up to two</strong> clinical decision support categories from the list below:
+                              <br/>
+                              <p>Please select <strong>up to two</strong> clinical decision support categories from the list below:</p>
                             </div>
                             <table class="table table-striped vf-col-6">
                               <thead>

--- a/src/components/AssessmentToolExit.vue
+++ b/src/components/AssessmentToolExit.vue
@@ -18,7 +18,7 @@
           @click="startNewAssessment"
           :columns="3" 
           :add-class="'me-2'">
-          <i class="bi bi-play-fill me-lg-2"></i><span class="d-lg-block d-none">Start a new assessment</span>
+          <i class="bi bi-play-fill me-lg-2"></i><span class="d-lg-block d-none">Start a new assessment or access completed assessment reports</span>
         </ButtonElement>
       </GroupElement>
       <SurveyLinkModal ref="surveyLinkModal" :showActionBtn="true" @modal-actioned="exit()" />


### PR DESCRIPTION
Changes final "start new assessment" button to say "start new assessment or access completed assessment reports". Wordy, true, but more informative, and Steph wanted it.

Also makes a minor adjustment to previous commit, adding a line break for space before the "select up to two" instruction on the intervention info section of scenarios page. Just looks better.