### PR TITLE
Fix for #341 - broken validation of ep system

### DIFF
--- a/src/components/AssessmentSelection.vue
+++ b/src/components/AssessmentSelection.vue
@@ -99,7 +99,7 @@
             :items="getEpSystemNames"
             :object="true"
             :messages="{required: 'Name of ePrescribing system is required'}"           
-            :rules="['required']"          
+            :rules="['required', $vueform.rules.nonEmptyObject]"          
           />
           <TextElement v-if="isOtherEpSystem" name="otherEpService" placeholder="Name of your eP system"
             :label="embolden('Name of ePrescribing system', true)"

--- a/vueform.config.js
+++ b/vueform.config.js
@@ -22,6 +22,18 @@ const nhsEmail = class extends Validator {
   }
 }
 
+const nonEmptyObject = class extends Validator {
+  get msg() {
+    return 'Please fill in this value'
+  }
+  check(value) {
+    if (typeof(value) === 'object') {
+      return Object.keys(value).length > 0
+    }
+    return false
+  }
+}
+
 const fieldIsOther = class extends Validator {
 
   get msg() {
@@ -99,6 +111,6 @@ export default defineConfig({
   displayMessages: false,
   floatPlaceholders: false,
   rules: {
-    nhsEmail, dateIsSameOrAfter, fieldIsOther
+    nhsEmail, nonEmptyObject, dateIsSameOrAfter, fieldIsOther
   }
 })


### PR DESCRIPTION
Adding correct validation rule 'nonEmptyObject' in vueform.config.js and referencing this in AssessmentSelection.vue line 102.  