### PR TITLE
Duplicate assessment bug, block registration

### DIFF
--- a/src/components/AppDashboard.vue
+++ b/src/components/AppDashboard.vue
@@ -49,8 +49,8 @@
                       <th class="align-content-center" colspan="9">Completed stage</th>
                     </tr>
                     <tr>
-                      <th scope="col" class="vertical-header col-1"><span>Code</span></th>
-                      <th scope="col" class="vertical-header col-2"><span>EP service</span></th>
+                      <th scope="col" class="vertical-header col-2"><span>Institution</span></th>
+                      <th scope="col" class="vertical-header col-1"><span>EP service</span></th>
                       <th scope="col" class="vertical-header col-1"><span>No assessment</span></th>
                       <th scope="col" class="vertical-header col-1"><span>Not started</span></th>
                       <th scope="col" class="vertical-header col-1"><span>System</span></th>
@@ -82,8 +82,8 @@
                       <th class="align-content-center" colspan="9">Completed stage</th>
                     </tr>
                     <tr>
-                      <th scope="col" class="vertical-header col-1"><span>Code</span></th>
-                      <th scope="col" class="vertical-header col-2"><span>EP service</span></th>
+                      <th scope="col" class="vertical-header col-2"><span>Institution</span></th>
+                      <th scope="col" class="vertical-header col-1"><span>EP service</span></th>
                       <th scope="col" class="vertical-header col-1"><span>No assessment</span></th>
                       <th scope="col" class="vertical-header col-1"><span>Not started</span></th>
                       <th scope="col" class="vertical-header col-1"><span>System</span></th>

--- a/src/components/AppLogin.vue
+++ b/src/components/AppLogin.vue
@@ -51,7 +51,7 @@
             <ButtonElement name="register" full 
               :columns="3" 
               :add-class="'mx-2'" 
-              :disabled="$route.query.action === 'registered'" 
+              :disabled="isDevelopmentSite || $route.query.action === 'registered'" 
               @click="onRegisterClick">
               <i class="bi bi-person-fill-add me-2"></i>Register
             </ButtonElement>
@@ -89,7 +89,10 @@ export default {
   computed: {
     ...mapState(authenticationStore, ['login', 'clear', 'isReporter']),
     ...mapState(rootStore, ['audit']),
-    ...mapState(assessmentStore, ['reset'])
+    ...mapState(assessmentStore, ['reset']),
+    isDevelopmentSite() {
+      return process.env.NODE_ENV === 'development'
+    }
   },
   data() {
     return {

--- a/src/components/AppWelcome.vue
+++ b/src/components/AppWelcome.vue
@@ -7,6 +7,10 @@
         The ePrescribing Risk and Safety Evaluation tool (ePRaSE) is designed to evaluate ePrescribing systems,
         in order to determine their effectiveness and to encourage the correct use of these systems
         and deliver improved patient outcomes.</p>
+        <div class="alert alert-danger fw-bold" v-if="isDevelopmentSite">
+          This is a test version of the site, NOT the live ePRaSE tool. Please DO NOT use this site, but instead go to the 
+          <a href="https://eprase.nhs.uk/" title="Live ePRaSE tool" target="_blank" style="text-decoration:underline">live version of the tool</a>
+        </div>
         <div class="row w-50 mx-auto">
           <Vueform>          
             <GroupElement name="buttonBar" :columns="12" :add-class="'mt-2'">
@@ -16,10 +20,10 @@
                 @click="onLoginClick">
                 <i class="bi bi-person-circle me-2"></i>Log in
               </ButtonElement>            
-              <ButtonElement name="register" full 
+              <ButtonElement name="register" full
                 :columns="6" 
                 :add-class="'mx-2'" 
-                :disabled="$route.query.action === 'registered'" 
+                :disabled="isDevelopmentSite || $route.query.action === 'registered'" 
                 @click="onRegisterClick">
                 <i class="bi bi-person-fill-add me-2"></i>Register
               </ButtonElement>
@@ -64,7 +68,10 @@ export default {
     AppLogo
   },
   computed: {
-    ...mapState(appSettingsStore, ['version', 'year'])
+    ...mapState(appSettingsStore, ['version', 'year']),
+    isDevelopmentSite() {
+      return process.env.NODE_ENV === 'development'
+    }
   },
   methods: {
     onLoginClick() {

--- a/src/components/Assessment.vue
+++ b/src/components/Assessment.vue
@@ -22,7 +22,7 @@
               :labels="{ next: 'Continue to System Information' }" />
             <FormStep name="systemInfoStep" label="ePrescribing System<br>Information"               
               :elements="['systemInfoEl']" 
-              :buttons="{ previous: false }"
+              :buttons="{ previous: this.duplicateAssessmentAttempt, next: !this.duplicateAssessmentAttempt }"
               :labels="{ 
                 next: 'Continue to Patient Build'
               }" />
@@ -102,7 +102,7 @@ export default {
   computed: {
     ...mapState(authenticationStore, ['isReporter']),
     ...mapState(appSettingsStore, ['version', 'year']),
-    ...mapState(assessmentStore, ['assessmentData', 'assessmentStateIndex']),
+    ...mapState(assessmentStore, ['assessmentData', 'duplicateAssessmentAttempt', 'assessmentStateIndex']),
     assessmentId() {
       return this.assessmentData.selection.assessmentId
     },   

--- a/src/components/AssessmentSelection.vue
+++ b/src/components/AssessmentSelection.vue
@@ -140,7 +140,7 @@ import { isoToUkDate } from '../helpers/utils'
 export default {
   name: 'AssessmentSelection',  
   computed: {
-    ...mapState(assessmentStore, ['allPossibleAssessments', 'assessmentData', 'loggingOut', 'dataReady', 'selectAssessment']),
+    ...mapState(assessmentStore, ['allPossibleAssessments', 'duplicateAssessmentAttempt', 'assessmentData', 'loggingOut', 'dataReady', 'selectAssessment']),
     ...mapState(authenticationStore, ['email', 'orgName', 'hospital']),
     ...mapState(rootStore, ['getEpSystems', 'audit']),
     selectionData() {
@@ -228,8 +228,8 @@ export default {
     if (!this.loggingOut && !this.continuingExistingAssessment) {
       // Create a new assessment (continuation / reporting will be handled by 'continueAssessment()' above)
       console.assert(this.dataLoaded, 'AssessmentSelection beforeUnmount() hook - dataReady flag is false')
-      const selectResponse = await this.selectAssessment()        
-      if (selectResponse !== true) {
+      const selectResponse = await this.selectAssessment()
+      if (!this.duplicateAssessmentAttempt && selectResponse !== true)        {
         throw new Error(selectResponse)
       } 
     }    


### PR DESCRIPTION
Adding some logic to stop duplicate assessments being created by multiple users in the same trust working at the same time.  Also prevent registration on dev site and prompt users to go to the live tool, NOT use the dev site for actual assessments!