### PR TITLE
Update AssessmentFinalReport.vue

### DIFF
--- a/src/components/AssessmentFinalReport.vue
+++ b/src/components/AssessmentFinalReport.vue
@@ -355,8 +355,10 @@ export default {
     this.auxiliaryDataReady = false
 
     let wasError = false
-    const updateResponse = await this.updateAssessmentStatus('Assessment complete', true)
-    wasError = await this.errorResponder(updateResponse)
+    if (!this.isReporter()) {
+      const updateResponse = await this.updateAssessmentStatus('Assessment complete', true)
+      wasError = await this.errorResponder(updateResponse)
+    }
     if (!wasError) {
       const patientBuildResponse = await this.patientListBuild(true)
       wasError = await this.errorResponder(patientBuildResponse)


### PR DESCRIPTION
When called from the reporter dashboard, the mounted() hook should not attempt to update the assessment status (the reporter role does not have privileges to do this, intentionally).